### PR TITLE
Saldovahvistusviesti

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -28928,6 +28928,10 @@ if (!function_exists('generoi_saldovahvistus_sahkopostit')) {
       }
       else {
         $saldovahvistus = $request['valitut_laskut'][$valittu_saldovahvistus];
+
+        //Valittu saldovahvistusviesti
+        $saldovahvistus['saldovahvistus_viesti'] = search_array_key_for_value_recursive($request['saldovahvistus_viestit'], 'selite', $request["valitut_laskut"][$valittu_saldovahvistus]["saldovahvistus_viesti"]);
+        $saldovahvistus['saldovahvistus_viesti'] = $saldovahvistus['saldovahvistus_viesti'][0];
       }
 
       if ($saldovahvistus['asiakas']['talhal_email'] != '') {


### PR DESCRIPTION
Saldovahvistus-ohjelmasta lähetettyihin sähköposteihin ei tullut saldovahvistusviestiä mukaan. Nyt tämä on korjattu niin, että saldovahvistusviesti saadaan sähköpostiin mukaan.