### PR TITLE
Selvittelytili

### DIFF
--- a/inc/viitemaksut_kohdistus.inc
+++ b/inc/viitemaksut_kohdistus.inc
@@ -496,7 +496,7 @@ while ($row = mysql_fetch_assoc($suorires)) {
     }
 
     // Jos meill‰ on oletus selvittelytili niin pistet‰‰n aina sinne tilille
-    if ($row["oletus_selvittelytili"] != "") {
+     if (!empty($row["oletus_selvittelytili"]) and $row["oletus_selvittelytili"] != $row["selvittelytili"]) {
       $row["myyntisaamiset"] = $row["oletus_selvittelytili"];
     }
 


### PR DESCRIPTION
Käytetään pankkitilin takana oletusselvittelytiliä vain jos se on eri kuin yhtiön tiedoissa oleva selvittelytili