### PR TITLE
Tuotteen avainsanojen tarkistukseen mukaan avainsanan selite

### DIFF
--- a/inc/tuotteen_avainsanattarkista.inc
+++ b/inc/tuotteen_avainsanattarkista.inc
@@ -161,22 +161,6 @@ if (!function_exists("tuotteen_avainsanattarkista")) {
       if (mysql_num_rows($results) > 0) {
         $virhe[$tem_tuoteno_i] = $virhe[$i] = t("Avainsana annetuilla tiedoilla löytyy kannasta. Duplikaatit ovat kiellettyjä!");
       }
-      else {
-
-        $query = "SELECT tunnus
-                  FROM tuotteen_avainsanat
-                  WHERE yhtio     = '$kukarow[yhtio]'
-                  AND tuoteno     = '$tem_tuoteno'
-                  AND kieli       = '$tem_kieli'
-                  AND laji        = '$tem_laji'
-                  AND selite      = '$tem_selite'
-                  AND selitetark  = '$tem_selitetark'";
-        $results = pupe_query($query);
-
-        if (mysql_num_rows($results) > 0) {
-          $virhe[$tem_tuoteno_i] = $virhe[$i] = t("Avainsana annetuilla tiedoilla löytyy kannasta. Duplikaatit ovat kiellettyjä!");
-        }
-      }
     }
   }
 }

--- a/lue_data.php
+++ b/lue_data.php
@@ -1449,6 +1449,11 @@ if ($kasitellaan_tiedosto) {
             $valinta .= " and liitostunnus='$tpttrow[tunnus]' ";
           }
         }
+        elseif ($table_mysql == "tuotteen_avainsanat") {
+          if (in_array("SELITE", $taulunotsikot[$taulu])) {
+            $valinta .= " and selite = '" . $taulunrivit[$taulu][$eriviindex][array_search("SELITE", $taulunotsikot[$taulu])] . "'";
+          }
+        }
 
         $query = "SELECT *
                   FROM $table_mysql


### PR DESCRIPTION
Lisätty tuotteen avainsanojen tarkistukseeen selite, jotta voidaan tehdä samalla lajilla, mutta eri selitteellä olevia tuotteen avainsanoja. Tämän muutoksen seurauksena tuotteen selitettä ei voi enää muuttaa sisäänlue datan muuta-toiminnolla, koska laji ei tarkoita enää mitään yksittäistä tuotteen avainsaanaa ja toisaalta koska selite on osa duplikaattitarkistusta niin se ei voi olla osa jota muutetaan, koska se on osa hakua jolla muutettavaa tuotteen avainsanaa haetaan.