### PR TITLE
Keräyslista footer ominaisuuden laajennus

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -261,6 +261,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "VARTOIMTULOSTIN") $ulos .= "<option value='VARTOIMTULOSTIN' {$avain_sel['VARTOIMTULOSTIN']}>".t("Varaston toimipaikan tulostin")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "OPTISCANKOM") $ulos .= "<option value='OPTISCANKOM' $avain_sel[OPTISCANKOM]>".t("Optiscan oletuskeräyskommentti")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "ULKJARJLAHETE") $ulos .= "<option value='ULKJARJLAHETE' {$avain_sel['ULKJARJLAHETE']}>".t("Ulkoisen varastojärjestelmän lähete-email")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "KRLSTFOOTRAJAUS") $ulos .= "<option value='KRLSTFOOTRAJAUS' {$avain_sel['KRLSTFOOTRAJAUS']}>".t("Iso asiakkaan nimi keräyslistan footteriin")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Verkkokaupan avainsanat")."'>";
@@ -453,6 +454,68 @@ if ($_siirtovarastot and $_selitetark_2) {
     $ulos .= "<option value = '{$toimitustapa['tunnus']}' {$sel}>{$toimitustapa['selite']}</option>";
     $sel = "";
   }
+  $ulos .= "</select></td>";
+
+  $jatko = 0;
+  $tyyppi = 1;
+}
+
+if ($avain_sel['KRLSTFOOTRAJAUS'] == 'SELECTED' and $_selite) {
+  $query = "SELECT *
+            FROM varastopaikat
+            WHERE yhtio = '{$kukarow['yhtio']}'
+              AND tyyppi != 'P'
+            ORDER BY nimitys ASC";
+  $varasto_result = pupe_query($query);
+
+  $ulos .= "<td>";
+  $ulos .= "<select name = '$nimi'>";
+  $sel = "";
+  while ($varasto = mysql_fetch_assoc($varasto_result)) {
+    if ($varasto['tunnus'] == $trow[$i]) {
+      $sel = "SELECTED";
+    }
+    $ulos .= "<option value = '{$varasto['tunnus']}' {$sel}>{$varasto['nimitys']}</option>";
+    $sel = "";
+  }
+  $ulos .= "</select>";
+  $ulos .= "</td>";
+
+  $jatko = 0;
+  $tyyppi = 1;
+}
+
+if ($avain_sel['KRLSTFOOTRAJAUS'] == 'SELECTED' and $_selitetark) {
+  $query = "SELECT *
+            FROM toimitustapa
+            WHERE yhtio = '{$kukarow['yhtio']}'";
+  $toimitustapa_result = pupe_query($query);
+
+  $ulos .= "<td><select name = '$nimi'>";
+  $sel = "";
+
+  if ($trow[$i] == "kaikki") {
+    $sel_kaikki = "SELECTED";
+  }
+  elseif ($trow[$i] == "nouto") {
+    $sel_nouto = "SELECTED";
+  }
+  elseif ($trow[$i] == "ei_nouto") {
+    $sel_einouto = "SELECTED";
+  }
+
+  $ulos .= "<option value = 'kaikki' {$sel_kaikki}>Kaikki</option>";
+  $ulos .= "<option value = 'nouto' {$sel_nouto}>Nouto</option>";
+  $ulos .= "<option value = 'ei_nouto' {$sel_einouto}>Ei nouto</option>";
+
+  while ($toimitustapa = mysql_fetch_assoc($toimitustapa_result)) {
+    if ($toimitustapa['tunnus'] == $trow[$i]) {
+      $sel = "SELECTED";
+    }
+    $ulos .= "<option value = '{$toimitustapa['tunnus']}' {$sel}>{$toimitustapa['selite']}</option>";
+    $sel = "";
+  }
+
   $ulos .= "</select></td>";
 
   $jatko = 0;

--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -504,9 +504,9 @@ if ($avain_sel['KRLSTFOOTRAJAUS'] == 'SELECTED' and $_selitetark) {
     $sel_einouto = "SELECTED";
   }
 
-  $ulos .= "<option value = 'kaikki' {$sel_kaikki}>Kaikki</option>";
-  $ulos .= "<option value = 'nouto' {$sel_nouto}>Nouto</option>";
-  $ulos .= "<option value = 'ei_nouto' {$sel_einouto}>Ei nouto</option>";
+  $ulos .= "<option value = 'kaikki' {$sel_kaikki}>".t("Kaikki")."</option>";
+  $ulos .= "<option value = 'nouto' {$sel_nouto}>".t("Nouto")."</option>";
+  $ulos .= "<option value = 'ei_nouto' {$sel_einouto}>".t("Ei nouto")."</option>";
 
   while ($toimitustapa = mysql_fetch_assoc($toimitustapa_result)) {
     if ($toimitustapa['tunnus'] == $trow[$i]) {

--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -1316,16 +1316,46 @@ if (!function_exists('loppu_kerayslista')) {
         }
       }
 
-      $query = "SELECT nouto 
-                FROM lasku l
-                INNER JOIN toimitustapa tt
-                  ON (tt.yhtio = l.yhtio AND tt.selite = l.toimitustapa)
-                WHERE l.yhtio = '$laskurow[yhtio]'
-                  AND l.tunnus = '$laskurow[tunnus]'";
-      $tt_result = pupe_query($query);
-      if (mysql_num_rows($tt_result) == 1) {
-        $tt_row = mysql_fetch_assoc($tt_result);
-        $isoasiakasfooter = ($tt_row['nouto'] == 'o');
+      if ($laskurow['nimi'] != "Useita") {
+        $footer_avainsana = "";
+
+        $query = "SELECT toimitustapa.nouto,
+                    toimitustapa.tunnus
+                  FROM lasku
+                    INNER JOIN toimitustapa
+                      ON (toimitustapa.yhtio = lasku.yhtio 
+                        AND toimitustapa.selite = lasku.toimitustapa)
+                  WHERE lasku.yhtio = '$laskurow[yhtio]'
+                    AND lasku.tunnus = '$laskurow[tunnus]'";
+        $tt_result = pupe_query($query);
+        $tt_row = mysql_fetch_assoc($tt_result);   
+
+        // katsotaan eka onko kaikki-avainsana setattu tälle varastolle
+        // jolloin kaikkien yksittäisten asiakkaiden footeriin tuodaan iso asiakasnimi
+        $footer_avainsana = t_avainsana("KRLSTFOOTRAJAUS", "", "AND selite = {$laskurow['varasto']} AND selitetark = 'kaikki'", "", "", "selitetark");
+
+        if ($footer_avainsana == "") {
+          // sitten tarkistetaan onko toimitustapa nouto vai ei
+          // jos nouto etsitään nouto rajaus ja jos ei etsitään ei_nouto rajausta
+          if ($tt_row["nouto"] == "o") {
+            $footer_avainsana = t_avainsana("KRLSTFOOTRAJAUS", "", "AND selite = {$laskurow['varasto']} AND selitetark = 'nouto'", "", "", "selitetark");
+          }
+          else {
+            $footer_avainsana = t_avainsana("KRLSTFOOTRAJAUS", "", "AND selite = {$laskurow['varasto']} AND selitetark = 'ei_nouto'", "", "", "selitetark");
+          }          
+        }
+
+        // katsotaan vielä löytyykö tarkemmin toimitustapaan kohdistettu sääntö
+        if ($footer_avainsana == "") {
+          $footer_avainsana = t_avainsana("KRLSTFOOTRAJAUS", "", "AND selite = {$laskurow['varasto']} AND selitetark = '{$tt_row["tunnus"]}'", "", "", "selitetark");
+        }
+
+        if ($footer_avainsana != "") {
+          $isoasiakasfooter = true;
+        }
+        else {
+          $isoasiakasfooter = false;
+        }
       }
       else {
         $isoasiakasfooter = false;


### PR DESCRIPTION
Tehty oma avainsana jolla voi hallita keräyslistan isoa asiakasfootteria varaston ja toimitustavan perusteella. Rajaus tapahtuu ensisijaisesti varaston perusteella ja tämän jälkeen voi valita kohdistetaanko rajaus kaikkiin toimitustapoihin, vain noutoihin, vain ei noutoihin vai johonkin tiettyyn toimitustapaan.